### PR TITLE
Standardize repository under the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,21 @@
-Copyright (c) 2026 Shaista Shabbir. All Rights Reserved.
+MIT License
 
-This software and associated documentation files (the "Software") are the
-exclusive intellectual property of Shaista Shabbir, Research Associate at
-TU Dortmund University and the Lamarr Institute for Machine Learning and AI.
+Copyright (c) 2026 Shaista Shabbir
 
-NO PERMISSION is granted to:
-- Copy, modify, merge, publish, distribute, sublicense, or sell copies
-  of the Software without explicit written permission from the author.
-- Use the Software or any part thereof in academic publications, research
-  papers, or derivative works without citing the original author.
-- Reproduce any portion of this Software for commercial purposes.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-RESEARCH USE:
-Academic researchers may read and study the code for non-commercial research
-purposes only. Any publication derived from or inspired by this work MUST cite:
-
-  Shabbir, Shaista. (2026). [Software title].
-  TU Dortmund University / Lamarr Institute for ML & AI.
-  GitHub: https://github.com/ShaistaShabbir-prog/
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED. THE AUTHOR ACCEPTS NO LIABILITY FOR ANY DAMAGES ARISING FROM USE
-OF THIS SOFTWARE.
-
-For licensing inquiries: contact via GitHub profile.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Academic Portfolio · TU Dortmund University · Lamarr Institute for ML & AI</p>
 [![Live](https://img.shields.io/badge/🌐_Live-shaistashabbir--prog.github.io-7C3AED?style=for-the-badge)](https://shaistashabbir-prog.github.io)
 [![Pages](https://img.shields.io/badge/GitHub_Pages-Built-16A34A?style=for-the-badge&logo=github)](https://shaistashabbir-prog.github.io)
 [![HTML](https://img.shields.io/badge/HTML5_+_CSS3-E34F26?style=for-the-badge&logo=html5&logoColor=white)](https://shaistashabbir-prog.github.io)
-[![License](https://img.shields.io/badge/License-Personal_Property-red?style=for-the-badge)](./LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](./LICENSE)
 
 </div>
 
@@ -104,4 +104,4 @@ Frequency Response Function analysis using H1/H2 estimators for resonance identi
 
 ## 📄 License
 
-Personal property — All rights reserved © 2026 Shaista Shabbir.
+MIT License - see [LICENSE](./LICENSE).


### PR DESCRIPTION
Replaces the personal-property license with the canonical MIT License and updates README metadata.