### PR TITLE
feat: add skills section + SEO meta tags + structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,6 +652,66 @@ header {
     </div>
   </section>
 
+
+  <!-- Skills Section -->
+  <section id="skills" class="section">
+    <div class="container">
+      <h2 class="section-title">Technical Skills</h2>
+      <div class="skills-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:20px;margin-top:24px">
+        <div class="skill-group" style="background:var(--card,#1a1f2e);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:20px">
+          <h3 style="font-size:.85rem;font-weight:700;color:#a78bfa;margin-bottom:12px;text-transform:uppercase;letter-spacing:.08em">AI / ML</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <span class="skill-tag">Python</span><span class="skill-tag">PyTorch</span><span class="skill-tag">TensorFlow / Keras</span>
+            <span class="skill-tag">scikit-learn</span><span class="skill-tag">LangChain</span><span class="skill-tag">LlamaIndex</span>
+            <span class="skill-tag">SHAP / XAI</span><span class="skill-tag">Optuna / AutoML</span><span class="skill-tag">FAISS / ChromaDB</span>
+          </div>
+        </div>
+        <div class="skill-group" style="background:var(--card,#1a1f2e);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:20px">
+          <h3 style="font-size:.85rem;font-weight:700;color:#34d399;margin-bottom:12px;text-transform:uppercase;letter-spacing:.08em">Data Engineering</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <span class="skill-tag">Pandas</span><span class="skill-tag">NumPy</span><span class="skill-tag">SQL / PostgreSQL</span>
+            <span class="skill-tag">ETL Pipelines</span><span class="skill-tag">Apache Airflow</span><span class="skill-tag">dbt</span>
+            <span class="skill-tag">Docker</span><span class="skill-tag">MLflow</span>
+          </div>
+        </div>
+        <div class="skill-group" style="background:var(--card,#1a1f2e);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:20px">
+          <h3 style="font-size:.85rem;font-weight:700;color:#60a5fa;margin-bottom:12px;text-transform:uppercase;letter-spacing:.08em">Backend / APIs</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <span class="skill-tag">FastAPI</span><span class="skill-tag">REST APIs</span><span class="skill-tag">Redis</span>
+            <span class="skill-tag">Docker / Compose</span><span class="skill-tag">GitHub Actions</span><span class="skill-tag">Pytest</span>
+          </div>
+        </div>
+        <div class="skill-group" style="background:var(--card,#1a1f2e);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:20px">
+          <h3 style="font-size:.85rem;font-weight:700;color:#fbbf24;margin-bottom:12px;text-transform:uppercase;letter-spacing:.08em">Frontend</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <span class="skill-tag">Next.js 15</span><span class="skill-tag">React</span><span class="skill-tag">TypeScript</span>
+            <span class="skill-tag">Tailwind CSS</span><span class="skill-tag">Astro</span><span class="skill-tag">HTML / CSS / JS</span>
+          </div>
+        </div>
+        <div class="skill-group" style="background:var(--card,#1a1f2e);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:20px">
+          <h3 style="font-size:.85rem;font-weight:700;color:#f87171;margin-bottom:12px;text-transform:uppercase;letter-spacing:.08em">Research</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:6px">
+            <span class="skill-tag">RAG Systems</span><span class="skill-tag">Knowledge Graphs</span><span class="skill-tag">NLP</span>
+            <span class="skill-tag">Privacy / MIA</span><span class="skill-tag">XAI / SHAP / LIME</span><span class="skill-tag">Signal Processing</span>
+            <span class="skill-tag">Chatter Detection</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <style>
+    .skill-tag {
+      display: inline-flex;
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-size: .72rem;
+      font-weight: 600;
+      background: rgba(255,255,255,.07);
+      border: 1px solid rgba(255,255,255,.1);
+      color: rgba(255,255,255,.75);
+    }
+  </style>
+
 </main>
 
 <footer style="background:linear-gradient(135deg,#0f0c29,#1a0533);color:rgba(255,255,255,.4);text-align:center;padding:1.5rem 1.25rem;font-size:.8125rem;margin-top:0">


### PR DESCRIPTION
Closes #10, Closes #15

- **Skills section** — 5 categories: AI/ML, Data Engineering, Backend, Frontend, Research — skill tag design
- **Open Graph** — og:title, og:description, og:type
- **Schema.org Person** — structured data for Google rich results
- **robots meta** — index, follow