### PR TITLE
feat: issues #27-30 — CV page, case study, GitHub stats, animations

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>CV | Shaista Shabbir</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  @media print {
+    nav, .no-print, #theme-toggle { display: none !important; }
+    body { background: #fff; color: #000; }
+    .card { border: 1px solid #ddd; break-inside: avoid; }
+    a { color: #000; }
+  }
+  .cv-section { margin-bottom: 2rem; }
+  .cv-entry { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 12px; }
+  .cv-date { font-size: .8rem; color: var(--text-muted); white-space: nowrap; flex-shrink: 0; }
+  .cv-role { font-weight: 700; color: var(--text-dark); }
+  .cv-org { color: var(--text-muted); font-size: .875rem; }
+</style>
+</head>
+<body>
+<header><div class="nav-main">
+  <a class="nav-brand" href="index.html">Shaista Shabbir</a>
+  <div class="nav-links">
+    <a href="index.html">Home</a>
+    <a href="projects.html">Research</a>
+    <a href="publications.html">Publications</a>
+    <a href="cv.html" class="active">CV</a>
+  </div>
+</div></header>
+
+<div class="hero" style="padding:60px 1.5rem 40px">
+  <div class="wrap">
+    <span class="eyebrow">Curriculum Vitae</span>
+    <h1 class="hero-title">Shaista Shabbir</h1>
+    <p class="hero-sub">Industrial AI Researcher · TU Dortmund University · Lamarr Institute</p>
+    <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:16px">
+      <button onclick="window.print()" class="hbtn hbtn-primary">⬇️ Download PDF</button>
+      <a href="mailto:shaista.s.shabbir@gmail.com" class="hbtn hbtn-ghost">✉️ Contact</a>
+    </div>
+  </div>
+</div>
+
+<main class="wrap" style="padding:3rem 0 5rem">
+  <div style="max-width:760px">
+
+    <div class="cv-section card">
+      <h2 class="sec-title" style="margin-bottom:16px"><span class="sec-title-accent">Education</span></h2>
+      <div class="cv-entry">
+        <div>
+          <div class="cv-role">M.Sc. Data Science</div>
+          <div class="cv-org">TU Dortmund University, Germany</div>
+          <div style="font-size:.82rem;color:var(--text);margin-top:4px">Focus: XAI, NLP, Privacy-preserving ML, Industrial AI</div>
+        </div>
+        <div class="cv-date">2022 – 2024</div>
+      </div>
+      <div class="cv-entry">
+        <div>
+          <div class="cv-role">B.Sc. Computer Science</div>
+          <div class="cv-org">University of Engineering &amp; Technology, Pakistan</div>
+        </div>
+        <div class="cv-date">2018 – 2022</div>
+      </div>
+    </div>
+
+    <div class="cv-section card">
+      <h2 class="sec-title" style="margin-bottom:16px"><span class="sec-title-accent">Experience</span></h2>
+      <div class="cv-entry">
+        <div>
+          <div class="cv-role">Research Associate</div>
+          <div class="cv-org">Lamarr Institute for Machine Learning and Artificial Intelligence, TU Dortmund</div>
+          <ul style="font-size:.82rem;color:var(--text);margin-top:6px;padding-left:16px;line-height:2">
+            <li>XAI methods (SHAP, LIME, Anchors) for industrial CNC machining processes</li>
+            <li>Membership inference attacks on NLP models trained on industrial sensor data</li>
+            <li>RAG pipeline development with LangChain, FAISS, Claude API</li>
+            <li>Knowledge graph construction for multi-hazard disaster intelligence</li>
+          </ul>
+        </div>
+        <div class="cv-date">2024 – present</div>
+      </div>
+    </div>
+
+    <div class="cv-section card">
+      <h2 class="sec-title" style="margin-bottom:16px"><span class="sec-title-accent">Technical Skills</span></h2>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+        <div>
+          <div style="font-size:.72rem;font-weight:700;color:#7c3aed;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px">AI / ML</div>
+          <div style="display:flex;flex-wrap:wrap;gap:5px">
+            <span class="tag">Python</span><span class="tag">PyTorch</span><span class="tag">TensorFlow</span>
+            <span class="tag">scikit-learn</span><span class="tag">LangChain</span><span class="tag">SHAP</span>
+            <span class="tag">Optuna</span><span class="tag">MLflow</span><span class="tag">FAISS</span>
+          </div>
+        </div>
+        <div>
+          <div style="font-size:.72rem;font-weight:700;color:#0d9488;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px">Backend / Data</div>
+          <div style="display:flex;flex-wrap:wrap;gap:5px">
+            <span class="tag">FastAPI</span><span class="tag">PostgreSQL</span><span class="tag">Docker</span>
+            <span class="tag">Next.js</span><span class="tag">TypeScript</span><span class="tag">GitHub Actions</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="cv-section card">
+      <h2 class="sec-title" style="margin-bottom:16px"><span class="sec-title-accent">Languages</span></h2>
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px">
+        <div class="tag" style="padding:8px 12px">🇵🇰 Urdu — Native</div>
+        <div class="tag" style="padding:8px 12px">🇬🇧 English — C1</div>
+        <div class="tag" style="padding:8px 12px">🇩🇪 German — B1</div>
+      </div>
+    </div>
+
+  </div>
+</main>
+<footer><div class="wrap"><p>Shaista Shabbir · Research Associate · TU Dortmund University</p></div></footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -777,6 +777,22 @@ header {
     </div>
   </section>
 
+
+  <!-- GitHub Stats Section -->
+  <section class="sec" id="github-stats">
+    <h2 class="sec-title"><span class="sec-title-accent">Open Source Activity</span></h2>
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;margin-top:16px">
+      <div style="display:flex;flex-wrap:wrap;gap:14px;justify-content:center">
+        <img src="https://github-readme-stats.vercel.app/api?username=ShaistaShabbir-prog&show_icons=true&theme=tokyonight&hide_border=true&count_private=true&bg_color=f8fafc&title_color=7c3aed&text_color=374151&icon_color=7c3aed" 
+             alt="GitHub Stats" height="165" loading="lazy" style="border-radius:12px;max-width:100%">
+        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=ShaistaShabbir-prog&layout=compact&theme=tokyonight&hide_border=true&bg_color=f8fafc&title_color=7c3aed&text_color=374151" 
+             alt="Top Languages" height="165" loading="lazy" style="border-radius:12px;max-width:100%">
+      </div>
+      <img src="https://streak-stats.demolab.com/?user=ShaistaShabbir-prog&theme=tokyonight&hide_border=true&background=f8fafc&ring=7c3aed&fire=ec4899&currStreakLabel=374151&sideLabels=374151&dates=374151" 
+           alt="GitHub Streak" loading="lazy" style="border-radius:12px;max-width:100%">
+    </div>
+  </section>
+
 </main>
 
 <footer style="background:linear-gradient(135deg,#0f0c29,#1a0533);color:rgba(255,255,255,.4);text-align:center;padding:1.5rem 1.25rem;font-size:.8125rem;margin-top:0">
@@ -800,5 +816,52 @@ header {
   };
 })();
 </script>
+
+<!-- Scroll animations (Issue #30) -->
+<script>
+(function(){
+  // Intersection Observer for fade-in on scroll
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.style.opacity = '1';
+        e.target.style.transform = 'translateY(0)';
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.sec, .card, .pub-card').forEach(el => {
+    if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+      el.style.opacity = '0';
+      el.style.transform = 'translateY(20px)';
+      el.style.transition = 'opacity .5s ease, transform .5s ease';
+    }
+    observer.observe(el);
+  });
+
+  // Typing effect on hero subtitle
+  const heroSub = document.querySelector('.hero-sub');
+  if (heroSub && window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+    const roles = ['Industrial AI Researcher', 'Full Stack Developer', 'Open Source Contributor'];
+    let roleIdx = 0, charIdx = 0, deleting = false;
+    const originalText = heroSub.textContent;
+    
+    function type() {
+      const role = roles[roleIdx];
+      if (!deleting) {
+        heroSub.textContent = role.substring(0, charIdx++);
+        if (charIdx > role.length) { deleting = true; setTimeout(type, 1800); return; }
+      } else {
+        heroSub.textContent = role.substring(0, charIdx--);
+        if (charIdx < 0) { deleting = false; roleIdx = (roleIdx + 1) % roles.length; charIdx = 0; }
+      }
+      setTimeout(type, deleting ? 40 : 80);
+    }
+    // Start after 2 seconds
+    setTimeout(type, 2000);
+  }
+})();
+</script>
+
 </body>
 </html>

--- a/projects/research-os.html
+++ b/projects/research-os.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ResearchOS Case Study | Shaista Shabbir</title>
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+<header><div class="nav-main">
+  <a class="nav-brand" href="../index.html">Shaista Shabbir</a>
+  <div class="nav-links"><a href="../projects.html">Research</a><a href="../publications.html">Publications</a></div>
+</div></header>
+
+<div class="hero" style="padding:60px 1.5rem 40px">
+  <div class="wrap">
+    <a href="../projects.html" style="color:#a78bfa;font-size:.85rem;text-decoration:none">← All projects</a>
+    <span class="eyebrow" style="margin-top:12px">Case Study</span>
+    <h1 class="hero-title">ResearchOS — AI Peer Review Platform</h1>
+    <p class="hero-sub">How I built a Claude-powered research paper analysis system from scratch</p>
+  </div>
+</div>
+
+<main class="wrap" style="padding:3rem 0 5rem;max-width:760px">
+  <div class="card">
+    <h2 class="sec-title"><span class="sec-title-accent">Problem</span></h2>
+    <p>Peer review quality varies widely. Reviewers miss reproducibility issues, statistical errors, and unsupported claims. Area chairs have no tools to quickly synthesise conflicting reviews. The process is manual, slow, and inconsistent.</p>
+  </div>
+  <div class="card">
+    <h2 class="sec-title"><span class="sec-title-accent">Solution</span></h2>
+    <p>An AI-powered platform that analyses papers across 6 dimensions: claims validation, reproducibility scoring, citation checking, reviewer fatigue detection, semantic similarity, and structured badge generation. Claude API provides the AI layer; heuristic fallbacks ensure the system works without an API key.</p>
+  </div>
+  <div class="card">
+    <h2 class="sec-title"><span class="sec-title-accent">Architecture</span></h2>
+    <ul style="font-size:.875rem;color:var(--text);line-height:2.2;padding-left:16px">
+      <li><strong>Frontend:</strong> Next.js 14, TypeScript, Tailwind CSS → Vercel</li>
+      <li><strong>Backend:</strong> FastAPI (Python), SQLite, 29 REST endpoints → Render.com</li>
+      <li><strong>AI:</strong> Anthropic Claude API (claude-haiku for fast tasks, claude-sonnet for deep review)</li>
+      <li><strong>Auth:</strong> JWT (HMAC-SHA256), PBKDF2 passwords, API key system</li>
+      <li><strong>Tests:</strong> 247+ tests, GitHub Actions CI</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h2 class="sec-title"><span class="sec-title-accent">Key results</span></h2>
+    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:8px">
+      <div style="text-align:center;padding:16px;background:rgba(124,58,237,.06);border-radius:12px">
+        <div style="font-size:2rem;font-weight:900;color:#7c3aed">247+</div>
+        <div style="font-size:.75rem;color:var(--text-muted)">Tests passing</div>
+      </div>
+      <div style="text-align:center;padding:16px;background:rgba(13,148,136,.06);border-radius:12px">
+        <div style="font-size:2rem;font-weight:900;color:#0d9488">29</div>
+        <div style="font-size:.75rem;color:var(--text-muted)">API endpoints</div>
+      </div>
+      <div style="text-align:center;padding:16px;background:rgba(236,72,153,.06);border-radius:12px">
+        <div style="font-size:2rem;font-weight:900;color:#ec4899">8</div>
+        <div style="font-size:.75rem;color:var(--text-muted)">AI tools</div>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <h2 class="sec-title"><span class="sec-title-accent">Lessons learned</span></h2>
+    <ul style="font-size:.875rem;color:var(--text);line-height:2.2;padding-left:16px">
+      <li>Heuristic fallbacks are essential — AI APIs have rate limits and costs</li>
+      <li>JWT without external libraries reduces dependencies and attack surface</li>
+      <li>Streaming responses dramatically improve perceived performance for long analyses</li>
+      <li>Type-safe API client (TypeScript) catches bugs before runtime</li>
+    </ul>
+  </div>
+  <div style="display:flex;gap:10px;margin-top:16px">
+    <a href="https://research-os-phi.vercel.app" target="_blank" rel="noopener" class="hbtn hbtn-primary">▶ Live Demo</a>
+    <a href="https://github.com/ShaistaShabbir-prog/research-os" target="_blank" rel="noopener" class="hbtn hbtn-ghost">GitHub →</a>
+  </div>
+</main>
+<footer><div class="wrap"><p>Shaista Shabbir · Research Associate · TU Dortmund University</p></div></footer>
+</body>
+</html>


### PR DESCRIPTION
Closes #27, #28, #29, #30

- `cv.html` — styled HTML CV with print-to-PDF, all sections
- `projects/research-os.html` — ResearchOS case study with metrics
- `index.html` — GitHub stats cards + scroll animations + hero typing effect